### PR TITLE
Switch to kwargs and lower case the epsg spec

### DIFF
--- a/Coordinate_transform.ipynb
+++ b/Coordinate_transform.ipynb
@@ -92,8 +92,8 @@
    },
    "outputs": [],
    "source": [
-    "utm16_wgs84 = pp.Proj(\"+init=EPSG:32616\") \n",
-    "utm15_nad27 = pp.Proj(\"+init=EPSG:26715\")"
+    "utm16_wgs84 = pp.Proj(init=\'epsg:32616\') \n",
+    "utm15_nad27 = pp.Proj(init=\'epsg:26715\')"
    ]
   },
   {


### PR DESCRIPTION
Great notebook! A couple things: 
1. pyproj lets you use keyword arguments in the `Proj()` constructor, which is better Python. For example, `Proj(proj='utm', zone=18)` instead of `Proj('+proj=utm +zone=18')`.
2. You must lowercase the epsg identifiers for this to work on case-sensitive filesystems like Linux. On OS X, 'EPSG:4326' tells PROJ.4 to look for the 4326 record in a file named "EPSG", and since OS X is case-insensitive, it finds and opens the file that is actually named "epsg".
